### PR TITLE
Change Git Repository for HTML-AutoCloseTag

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -244,7 +244,7 @@
 
     " HTML {
         if count(g:spf13_bundle_groups, 'html')
-            Bundle 'amirh/HTML-AutoCloseTag'
+            Bundle 'heracek/HTML-AutoCloseTag'
             Bundle 'hail2u/vim-css3-syntax'
             Bundle 'gorodinskiy/vim-coloresque'
             Bundle 'tpope/vim-haml'


### PR DESCRIPTION
Old repository in amirh/HTML-AutoCloseTag does not exist anymore.
Change to heracek/HTML-AutoCloseTag.